### PR TITLE
fix for calculation of sample size (so as to match R CPS.ssize function)

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -46,7 +46,7 @@
           var p = (p1 + r*p2) / (1 + r);
           var n = za * Math.sqrt((1 + r) * p * (1 - p)) + 
                    zb * Math.sqrt(r * p1 * (1 - p1) + p2 * (1 - p2));
-          var m1 = Math.pow(n, 2) / Math.pow(r * (p1 - p2), 2);
+          var m1 = Math.pow(n, 2) / (r * Math.pow(p1 - p2, 2));
           var m = (
               (m1 / 4) * 
               Math.pow(


### PR DESCRIPTION
tested the cps_ssize function against the R function CPS.ssize (from clinfun package) and outputs now match up
